### PR TITLE
Fix request signing when id=* is present

### DIFF
--- a/lib/usabilla_api/usabilla_api.rb
+++ b/lib/usabilla_api/usabilla_api.rb
@@ -79,7 +79,7 @@ module UsabillaApi
     end
 
     def sub_query_id(uri)
-      uri.gsub(':id', @query_id)
+      uri.gsub(':id', CGI.escape(@query_id))
     end
 
     def since_filter(amount)


### PR DESCRIPTION
This solves auth problem for `id=*`.
I think API docs doesn't mentions that `*` should be encoded using percents (it says so for other chars), but the official Node.js client does it.

https://github.com/usabilla/api-js-node/blob/94efc4216279e28d5f8647b7c7e9f292d2d23534/src/signing.js#L40

